### PR TITLE
Support translations for about page

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,9 +1,36 @@
+import { use } from "react";
+import { Metadata, NextPage } from "next";
+import {
+  WORK_EXPERIENCES,
+  EDUCATION_EXPERIENCES,
+} from "../../../constants/experiences";
+import {
+  Bars4Icon,
+  BriefcaseIcon,
+  BuildingLibraryIcon,
+} from "@heroicons/react/20/solid";
+import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { useTranslations } from "next-intl";
-import { WORK_EXPERIENCES, EDUCATION_EXPERIENCES } from "@/constants/experiences";
+import { DEFAULT_LOCALE } from "@/constants/locales";
 import { ExperienceWorkCard } from "@/components/experience/WorkCard";
 import { ExperienceEducationCard } from "@/components/experience/EducationCard";
+import Certifications from "@/components/about/Certifications";
 
-export default function AboutPage() {
+type Props = {
+  params: Promise<{ locale?: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale = DEFAULT_LOCALE } = await params;
+  const t = await getTranslations({ locale, namespace: "About" });
+  return {
+    title: t("title"),
+  };
+}
+
+export default function AboutPage({ params }: Props) {
+  const { locale = DEFAULT_LOCALE } = use(params);
+  unstable_setRequestLocale(locale);
   const t = useTranslations("About");
 
   const translatedWorkExperiences = WORK_EXPERIENCES.map((experience) => ({
@@ -26,20 +53,45 @@ export default function AboutPage() {
   }));
 
   return (
-    <div>
-      <h1>{t("title")}</h1>
-      <section>
-        <h2>{t("work.title")}</h2>
-        {translatedWorkExperiences.map((experience) => (
-          <ExperienceWorkCard key={experience.id} {...experience} />
-        ))}
-      </section>
-      <section>
-        <h2>{t("education.title")}</h2>
-        {translatedEducationExperiences.map((experience) => (
-          <ExperienceEducationCard key={experience.id} {...experience} />
-        ))}
-      </section>
-    </div>
+    <section
+      data-testid="projects"
+      className="container flex flex-col items-center justify-center gap-4"
+    >
+      <h1 className="font-monospace flex flex-row items-center gap-4 text-center text-3xl dark:text-white lg:text-4xl">
+        <Bars4Icon className="h-8 w-8" />
+        {t("title")}
+      </h1>
+      <div className="mt-4 flex flex-col gap-4 p-4">
+        <div className="container">
+          <h2 className="mb-6 flex flex-row items-center gap-3 text-left text-2xl font-semibold lg:text-3xl">
+            <BriefcaseIcon className="h-8 w-8" />
+            {t("work.title")}
+          </h2>
+          <div className="flex grid-cols-12 flex-col md:grid">
+            {translatedWorkExperiences.map((p) => (
+              <ExperienceWorkCard key={p.id} {...p} />
+            ))}
+          </div>
+        </div>
+        <div className="container">
+          <h2 className="mb-6 flex flex-row items-center gap-3 text-left text-2xl font-semibold lg:text-3xl">
+            <BuildingLibraryIcon className="h-8 w-8" />
+            {t("education.title")}
+          </h2>
+          <div className="flex grid-cols-12 flex-col md:grid">
+            {translatedEducationExperiences.map((p) => (
+              <ExperienceEducationCard key={p.id} {...p} />
+            ))}
+          </div>
+        </div>
+        <div className="container">
+          <h2 className="mb-6 flex flex-row items-center gap-3 text-left text-2xl font-semibold lg:text-3xl">
+            <BuildingLibraryIcon className="h-8 w-8" />
+            {t("courseCertifications.title")}
+          </h2>
+          <Certifications/>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,77 +1,45 @@
-import { use } from "react";
-import { Metadata, NextPage } from "next";
-import {
-  WORK_EXPERIENCES,
-  EDUCATION_EXPERIENCES,
-} from "../../../constants/experiences";
-import {
-  Bars4Icon,
-  BriefcaseIcon,
-  BuildingLibraryIcon,
-} from "@heroicons/react/20/solid";
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 import { useTranslations } from "next-intl";
-import { DEFAULT_LOCALE } from "@/constants/locales";
+import { WORK_EXPERIENCES, EDUCATION_EXPERIENCES } from "@/constants/experiences";
 import { ExperienceWorkCard } from "@/components/experience/WorkCard";
 import { ExperienceEducationCard } from "@/components/experience/EducationCard";
-import Certifications from "@/components/about/Certifications";
 
-type Props = {
-  params: Promise<{ locale?: string }>;
-};
-
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { locale = DEFAULT_LOCALE } = await params;
-  const t = await getTranslations({ locale, namespace: "About" });
-  return {
-    title: t("title"),
-  };
-}
-
-export default function AboutPage({ params }: Props) {
-  const { locale = DEFAULT_LOCALE } = use(params);
-  unstable_setRequestLocale(locale);
+export default function AboutPage() {
   const t = useTranslations("About");
+
+  const translatedWorkExperiences = WORK_EXPERIENCES.map((experience) => ({
+    ...experience,
+    company: t(`work.experiences.${experience.id}.company`),
+    location: t(`work.experiences.${experience.id}.location`),
+    position: t(`work.experiences.${experience.id}.position`),
+    start: t(`work.experiences.${experience.id}.start`),
+    end: t(`work.experiences.${experience.id}.end`),
+    tasks: experience.tasks.map((task, index) => t(`work.experiences.${experience.id}.tasks.${index}`)),
+  }));
+
+  const translatedEducationExperiences = EDUCATION_EXPERIENCES.map((experience) => ({
+    ...experience,
+    institution: t(`education.experiences.${experience.id}.institution`),
+    location: t(`education.experiences.${experience.id}.location`),
+    degree: t(`education.experiences.${experience.id}.degree`),
+    start: t(`education.experiences.${experience.id}.start`),
+    end: t(`education.experiences.${experience.id}.end`),
+  }));
+
   return (
-    <section
-      data-testid="projects"
-      className="container flex flex-col items-center justify-center gap-4"
-    >
-      <h1 className="font-monospace flex flex-row items-center gap-4 text-center text-3xl dark:text-white lg:text-4xl">
-        <Bars4Icon className="h-8 w-8" />
-        {t("title")}
-      </h1>
-      <div className="mt-4 flex flex-col gap-4 p-4">
-        <div className="container">
-          <h2 className="mb-6 flex flex-row items-center gap-3 text-left text-2xl font-semibold lg:text-3xl">
-            <BriefcaseIcon className="h-8 w-8" />
-            {t("work.title")}
-          </h2>
-          <div className="flex grid-cols-12 flex-col md:grid">
-            {WORK_EXPERIENCES.map((p) => (
-              <ExperienceWorkCard key={p.id} {...p} />
-            ))}
-          </div>
-        </div>
-        <div className="container">
-          <h2 className="mb-6 flex flex-row items-center gap-3 text-left text-2xl font-semibold lg:text-3xl">
-            <BuildingLibraryIcon className="h-8 w-8" />
-            {t("education.title")}
-          </h2>
-          <div className="flex grid-cols-12 flex-col md:grid">
-            {EDUCATION_EXPERIENCES.map((p) => (
-              <ExperienceEducationCard key={p.id} {...p} />
-            ))}
-          </div>
-        </div>
-        <div className="container">
-          <h2 className="mb-6 flex flex-row items-center gap-3 text-left text-2xl font-semibold lg:text-3xl">
-            <BuildingLibraryIcon className="h-8 w-8" />
-            {t("courseCertifications.title")}
-          </h2>
-          <Certifications/>
-        </div>
-      </div>
-    </section>
+    <div>
+      <h1>{t("title")}</h1>
+      <section>
+        <h2>{t("work.title")}</h2>
+        {translatedWorkExperiences.map((experience) => (
+          <ExperienceWorkCard key={experience.id} {...experience} />
+        ))}
+      </section>
+      <section>
+        <h2>{t("education.title")}</h2>
+        {translatedEducationExperiences.map((experience) => (
+          <ExperienceEducationCard key={experience.id} {...experience} />
+        ))}
+      </section>
+    </div>
   );
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -67,7 +67,7 @@
       "title": "Work Experience"
     },
     "courseCertifications": {
-      "title": "Cursos y Certificaciones"
+      "title": "Courses and Certifications"
     },
     "description": "I am a software developer with 4 years of experience in the development of web applications, I have a degree in Systems Engineering and I am passionate about technology. "
   },
@@ -77,5 +77,95 @@
       "template": "%s |  Franz Bendezu - Software Developer"
     },
     "description": "Welcome to my personal website"
+  },
+  "work": {
+    "experiences": {
+      "1": {
+        "company": "Indra",
+        "location": "Lima, Peru",
+        "position": "Backend Developer AWS Senior",
+        "start": "September 2024",
+        "end": "Present",
+        "tasks": [
+          "Developed microservices in Java using Spring Flux and Reactive for legacy systems",
+          "Implemented microservices with TypeScript, Node.js, and Serverless Framework for orchestration of legacy systems",
+          "Managed databases like PostgreSQL, DynamoDB, and legacy databases like IBM Informix",
+          "Integrated microservices with AWS services such as Lambda, API Gateway, DynamoDB, PostgresRDS, SSM, Step Functions, and EKS"
+        ]
+      },
+      "2": {
+        "company": "Agendalo.io",
+        "location": "Lima, Peru",
+        "position": "Software Engineer Semi Senior",
+        "start": "August 2022",
+        "end": "July 2024",
+        "link": "https://agendalo.io/",
+        "tasks": [
+          "Led frontend development using Nuxt.js and supported backend projects",
+          "Migrated a single-page application (SPA) to server-side rendering (SSR) to improve SEO",
+          "Implemented CI/CD pipelines with containers, reducing delivery times by 20%",
+          "Developed OAuth2 authentication for integration with Google and Microsoft",
+          "Established payment gateways with Mercado Pago, Niubiz, and Stripe",
+          "Developed an administrative panel for resource management and user issue resolution via the WhatsApp API",
+          "Collaborated with the CTO to create internal libraries and migrate main applications to a monorepo"
+        ]
+      },
+      "3": {
+        "company": "Freelancer",
+        "location": "Remote",
+        "position": "Software Developer",
+        "start": "July 2019",
+        "end": "January 2024",
+        "tasks": [
+          "Developed and maintained client projects, specializing in frontend and backend technologies",
+          "Worked with technology stacks such as Java, Kotlin, JavaScript, TypeScript, Python, Vue.js, React, Angular, Spring Boot, and Node.js",
+          "Implemented REST APIs, GraphQL, and OAuth2 authentication protocols",
+          "Leveraged AWS services like S3, EC2, and Lambda for scalable solutions",
+          "Configured CI/CD pipelines using Docker, GitHub Actions, and GitLab",
+          "Optimized development processes with agile methodologies and SCRUM practices",
+          "Created reusable internal libraries to simplify development across multiple projects"
+        ]
+      },
+      "4": {
+        "company": "Gestión y Sistemas SAC",
+        "location": "Lima, Peru",
+        "position": "Junior Development Analyst",
+        "start": "August 2021",
+        "end": "October 2022",
+        "tasks": [
+          "Performed frontend development using Angular and managed repositories with Azure DevOps",
+          "Developed administrative panels for internal commission management at Banco Ripley",
+          "Contributed to the development of administrative panels for internal parameter management at Banco Falabella",
+          "Implemented a supplier portal for The Leaf Company (ACS) and an activity planning application",
+          "Collaborated closely with teams in Peru and Chile under SCRUM methodology"
+        ]
+      },
+      "5": {
+        "company": "Banco Ripley Peru",
+        "location": "Lima, Peru",
+        "position": "Frontend Developer",
+        "start": "August 2021",
+        "end": "October 2022",
+        "tasks": [
+          "Participated in frontend development of the cross-platform online banking app and payment platform",
+          "Collaborated closely with payment teams in Peru and Chile under SCRUM methodology",
+          "Used Angular and Ionic for developing intuitive user interfaces",
+          "Implemented transaction authorization widgets and integrated payment gateways",
+          "Performed incident analysis to implement improvements and new features, working in collaboration with the user experience (UX) team"
+        ]
+      }
+    }
+  },
+  "education": {
+    "experiences": {
+      "1": {
+        "institution": "National University of Engineering",
+        "location": "Lima, Peru",
+        "degree": "Systems Engineering",
+        "start": "2018",
+        "end": "2023",
+        "link": "https://www.uni.edu.pe/"
+      }
+    }
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -79,5 +79,95 @@
       "template": "%s |  Franz Bendezu - Desarrollador de Software"
     },
     "description": "Bienvenido a mi sitio web personal"
+  },
+  "work": {
+    "experiences": {
+      "1": {
+        "company": "Indra",
+        "location": "Lima, Perú",
+        "position": "Backend Developer AWS Senior",
+        "start": "Septiembre 2024",
+        "end": "Presente",
+        "tasks": [
+          "Desarrollé microservicios en Java utilizando Spring Flux y Reactive para sistemas heredados",
+          "Implementé microservicios con TypeScript, Node.js y Serverless Framework para la orquestación de sistemas heredados",
+          "Gestioné bases de datos como PostgreSQL, DynamoDB y bases heredadas como IBM Informix",
+          "Integré microservicios con servicios de AWS como Lambda, API Gateway, DynamoDB, PostgresRDS, SSM, Step Functions y EKS"
+        ]
+      },
+      "2": {
+        "company": "Agendalo.io",
+        "location": "Lima, Perú",
+        "position": "Software Engineer Semi Senior",
+        "start": "Agosto 2022",
+        "end": "Julio 2024",
+        "link": "https://agendalo.io/",
+        "tasks": [
+          "Lideré el desarrollo frontend utilizando Nuxt.js y apoyé en proyectos backend",
+          "Migré una aplicación de una sola página (SPA) a renderización del lado del servidor (SSR) para mejorar el SEO",
+          "Implementé pipelines CI/CD con contenedores, reduciendo los tiempos de entrega en un 20%",
+          "Desarrollé autenticación OAuth2 para integración con Google y Microsoft",
+          "Establecí pasarelas de pago con Mercado Pago, Niubiz y Stripe",
+          "Desarrollé un panel administrativo para la gestión de recursos y resolución de problemas de usuarios mediante la API de WhatsApp",
+          "Colaboré con el CTO para crear bibliotecas internas y migrar aplicaciones principales a un monorepo"
+        ]
+      },
+      "3": {
+        "company": "Freelancer",
+        "location": "Remoto",
+        "position": "Desarrollador de Software",
+        "start": "Julio 2019",
+        "end": "Enero 2024",
+        "tasks": [
+          "Desarrollé y mantuve proyectos de clientes, especializándome en tecnologías frontend y backend",
+          "Trabajé con stacks tecnológicos como Java, Kotlin, JavaScript, TypeScript, Python, Vue.js, React, Angular, Spring Boot y Node.js",
+          "Implementé APIs REST, GraphQL y protocolos de autenticación OAuth2",
+          "Aproveché servicios de AWS como S3, EC2 y Lambda para soluciones escalables",
+          "Configuré pipelines CI/CD utilizando Docker, GitHub Actions y GitLab",
+          "Optimicé los procesos de desarrollo con metodologías ágiles y prácticas SCRUM",
+          "Creé bibliotecas internas reutilizables para simplificar el desarrollo en múltiples proyectos"
+        ]
+      },
+      "4": {
+        "company": "Gestión y Sistemas SAC",
+        "location": "Lima, Perú",
+        "position": "Analista de Desarrollo Junior",
+        "start": "Agosto 2021",
+        "end": "Octubre 2022",
+        "tasks": [
+          "Realicé desarrollo frontend utilizando Angular y gestioné repositorios con Azure DevOps",
+          "Desarrollé paneles administrativos para la gestión interna de comisiones en Banco Ripley",
+          "Contribuí al desarrollo de paneles administrativos para la gestión interna de parámetros en Banco Falabella",
+          "Implementé un portal de proveedores para The Leaf Company (ACS) y una aplicación de planificación de actividades",
+          "Colaboré estrechamente con equipos en Perú y Chile bajo metodología SCRUM"
+        ]
+      },
+      "5": {
+        "company": "Banco Ripley Perú",
+        "location": "Lima, Perú",
+        "position": "Frontend Developer",
+        "start": "Agosto 2021",
+        "end": "Octubre 2022",
+        "tasks": [
+          "Participé en el desarrollo frontend de la app de banca online multiplataforma y la plataforma de pagos",
+          "Colaboré estrechamente con equipos de pagos en Perú y Chile bajo la metodología SCRUM",
+          "Utilicé Angular e Ionic para el desarrollo de interfaces de usuario intuitivas",
+          "Implementé widgets de autorización de transacciones e integré pasarelas de pago",
+          "Realicé análisis de incidentes para implementar mejoras y nuevas características, trabajando en colaboración con el equipo de experiencia de usuario (UX)"
+        ]
+      }
+    }
+  },
+  "education": {
+    "experiences": {
+      "1": {
+        "institution": "Universidad Nacional de Ingeniería",
+        "location": "Lima, Perú",
+        "degree": "Ingeniería de Sistemas",
+        "start": "2018",
+        "end": "2023",
+        "link": "https://www.uni.edu.pe/"
+      }
+    }
   }
 }


### PR DESCRIPTION
Add support for translations for the about page in `src/app/[locale]/about/page.tsx`.

* **About Page**: 
  - Import `WORK_EXPERIENCES` and `EDUCATION_EXPERIENCES` from `src/constants/experiences.ts`.
  - Import `useTranslations` from `next-intl`.
  - Use `useTranslations` to get translated `WORK_EXPERIENCES` and `EDUCATION_EXPERIENCES`.
  - Use `ExperienceWorkCard` to display translated work experiences.
  - Use `ExperienceEducationCard` to display translated education experiences.

* **English Translations**:
  - Add translation messages for `WORK_EXPERIENCES` and `EDUCATION_EXPERIENCES` in `src/messages/en.json`.

* **Spanish Translations**:
  - Add translation messages for `WORK_EXPERIENCES` and `EDUCATION_EXPERIENCES` in `src/messages/es.json`.

